### PR TITLE
Attempt to debug a bit the setup process

### DIFF
--- a/manifest.toml
+++ b/manifest.toml
@@ -88,4 +88,4 @@ ram.runtime = "50M"
     version = "20.15.1"
 
     [resources.ruby]
-    version = "3.1.2"
+    version = "3.3.8"

--- a/manifest.toml
+++ b/manifest.toml
@@ -86,6 +86,9 @@ ram.runtime = "50M"
 
     [resources.nodejs]
     version = "20.15.1"
+    packages= [
+      "svgo@1.3.2"
+    ]
 
     [resources.ruby]
     version = "3.3.8"

--- a/scripts/install
+++ b/scripts/install
@@ -36,7 +36,8 @@ ynh_config_add --template=".env" --destination="$install_dir/.env"
 #=================================================
 ynh_script_progression "Building $app..."
 
-yarn global add svgo@1.3.2
+# We'll try to install this in the "resource.nodejs" section of the manifest
+#yarn global add svgo@1.3.2
 
 pushd "$install_dir/"
     # Install dependencies

--- a/scripts/install
+++ b/scripts/install
@@ -58,8 +58,22 @@ ynh_script_progression "Configuring $app..."
 
 pushd "$install_dir/"
     export RAILS_ENV=production
-    ynh_exec_as_app bundle exec rails credentials:edit
+    # Sadly, this is a manual step for first install: "credentials:edit" opens a text editor (nano/vim),
+    # so you can add some values specific to the deployment. Once the editor closes, the file is hashed
+    # with the master key, which is also specific to the deployment.
+    #
+    # It is possible to use environment variables instead. Note that these values should be different for every instance:
+    export RAILS_MASTER_KEY=0000 # In theory, can be left as is, at it is only used to decrypt the file containing "SECRET_KEY_BASE"
+    export SECRET_KEY_BASE=0000 # used to hash password and cookies
+    export INSTANCE_SECRET_KEY_JWT=0000 # Used to generate JWT tokens
+    #ynh_exec_as_app bundle exec rails credentials:edit
+
+    # In general, you can use SECRET_KEY_BASE_DUMMY=1 for commands that don't require the
+    # SECRET_KEY_BASE or the INSTANCE_SECRET_KEY_JWT: it prevent Rails from checking for valid values.
+    # The downside is if you generate passwords or JWT tokens with it, they won't be valid.
+    # We won't use it for the migrations but we could.
     ynh_exec_as_app DATABASE_URL=postgresql://$db_user:$db_pwd@:5432/$db_name bundle exec rails db:migrate
+    # valid key base is required for this
     ynh_exec_as_app DATABASE_URL=postgresql://$db_user:$db_pwd@:5432/$db_name bundle exec rails db:seed
 popd
 

--- a/scripts/install
+++ b/scripts/install
@@ -48,7 +48,7 @@ pushd "$install_dir/"
     ynh_exec_as_app bundle config set --local path 'vendor/bundle'
     ynh_exec_as_app bundle config set --local deployment 'true'
     ynh_exec_as_app bundle config set --local without 'development test'
-    ynh_exec_as_app bundle install
+    #ynh_exec_as_app bundle install
 popd
 
 #=================================================
@@ -63,18 +63,18 @@ pushd "$install_dir/"
     # with the master key, which is also specific to the deployment.
     #
     # It is possible to use environment variables instead. Note that these values should be different for every instance:
-    export RAILS_MASTER_KEY=0000 # In theory, can be left as is, at it is only used to decrypt the file containing "SECRET_KEY_BASE"
+    #export RAILS_MASTER_KEY=0000 # In theory, can be left as is, at it is only used to decrypt the file containing "SECRET_KEY_BASE"
     export SECRET_KEY_BASE=0000 # used to hash password and cookies
-    export INSTANCE_SECRET_KEY_JWT=0000 # Used to generate JWT tokens
+    export INSTANCE_SECRET_KEY_JWT=ABCDE # Used to generate JWT tokens
     #ynh_exec_as_app bundle exec rails credentials:edit
 
     # In general, you can use SECRET_KEY_BASE_DUMMY=1 for commands that don't require the
     # SECRET_KEY_BASE or the INSTANCE_SECRET_KEY_JWT: it prevent Rails from checking for valid values.
     # The downside is if you generate passwords or JWT tokens with it, they won't be valid.
     # We won't use it for the migrations but we could.
-    ynh_exec_as_app DATABASE_URL=postgresql://$db_user:$db_pwd@:5432/$db_name bundle exec rails db:migrate
+    ynh_exec_as_app RAILS_ENV=production SECRET_KEY_BASE_DUMMY=1 DATABASE_URL=postgresql://$db_user:$db_pwd@localhost:5432/$db_name bundle exec rails db:migrate
     # valid key base is required for this
-    ynh_exec_as_app DATABASE_URL=postgresql://$db_user:$db_pwd@:5432/$db_name bundle exec rails db:seed
+    ynh_exec_as_app RAILS_ENV=production INSTANCE_SECRET_KEY_JWT=ABCDE SECRET_KEY_BASE=0000 DATABASE_URL=postgresql://$db_user:$db_pwd@localhost:5432/$db_name bundle exec rails db:seed
 popd
 
 #=================================================

--- a/scripts/install
+++ b/scripts/install
@@ -41,9 +41,14 @@ ynh_script_progression "Building $app..."
 
 pushd "$install_dir/"
     # Install dependencies
-    export RAILS_ENV=production 
-    ynh_exec_as_app bundle config deployment 'true'
-    ynh_exec_as_app bundle config without 'development test'
+    export RAILS_ENV=production
+
+    # Specify gems path (missing from the docs :/)
+    # Use "--local" to apply only for this directory
+    ynh_exec_as_app bundle config set --local path 'vendor/bundle'
+    ynh_exec_as_app bundle config set --local deployment 'true'
+    ynh_exec_as_app bundle config set --local without 'development test'
+    ynh_exec_as_app bundle install
 popd
 
 #=================================================


### PR DESCRIPTION
Following https://gitlab.com/experimentslabs/garden-party/garden-party/-/issues/172, here is an attempt to document the setup process and adapt it for YunoHost

The commits are a bit raw and should be used as reference (and **not be merged as-is**).

There are some things I don't know about how YunoHost works, as for generating values _per instance_, then use them as environment variables

Right now, the setup seems to work up to the database migrations (and sadly, I had to bundle again):

```log
 URI::InvalidURIError: the scheme postgresql does not accept registry part: garden_party:7902f7f12bc870e7e9d11aa3@:5432 (or bad hostname?) (URI::InvalidURIError)
```

It seems the host is missing from the URL, i'll check that next. 

At least, there are some insights for the first steps :)

Also, there are a bunch of supported environment variables, a commented list is available in [`docker/.env`](https://gitlab.com/experimentslabs/garden-party/garden-party/-/blob/develop/docker/.env)